### PR TITLE
Serializable classes now display fields in editor

### DIFF
--- a/Scripts/Utility/CustomInspectorScripts.cs
+++ b/Scripts/Utility/CustomInspectorScripts.cs
@@ -148,8 +148,8 @@ namespace CustomInspector
                     if (prop != null)
                     {
                         EditorGUILayout.PropertyField(prop);
-                        var depth = prop.depth + 1;
-                        if (prop.isArray && prop.isExpanded)
+                        var depth = prop.depth;
+                        if (prop.isExpanded)
                         {
                             bool runNext = prop.NextVisible(true);
                             while (runNext)


### PR DESCRIPTION
Before only arrays of user-defined serializable classes would show up in the custom editor. Also fixes incorrect indenting.